### PR TITLE
SCRUM-125-Wunschersteller-kann-eigenen-Wunsch-nicht-liken

### DIFF
--- a/src/app/api/event/participation/route.ts
+++ b/src/app/api/event/participation/route.ts
@@ -14,6 +14,21 @@ export async function POST(req: NextRequest) {
     return NextResponse.json({ error: 'Not authenticated' }, { status: 401 })
   }
 
+  // Ersteller-Schutz!
+  const event = await prisma.events.findUnique({
+    where: { eventId },
+    include: { users: true },
+  })
+
+  if (!event) {
+    return NextResponse.json({ error: 'Event not found' }, { status: 404 })
+  }
+
+  if (event.users.userId === user.id) {
+    return NextResponse.json({ error: 'Organizer cannot join own event' }, { status: 403 })
+  }
+  // Ersteller-Schutz!
+
   try {
     const existing = await prisma.eventParticipation.findFirst({
       where: {

--- a/src/app/api/wish/[id]/upvote/route.ts
+++ b/src/app/api/wish/[id]/upvote/route.ts
@@ -14,6 +14,21 @@ export async function POST(_req: Request, { params }: RouteContext) {
   const userId = user.id
 
   try {
+    // Ersteller-Schutz!
+    const wish = await prisma.wishes.findUnique({
+      where: { wishId: id },
+      include: { users: true },
+    })
+
+    if (!wish) {
+      return NextResponse.json({ error: 'Wish not found' }, { status: 404 })
+    }
+
+    if (wish.users.userId === userId) {
+      return NextResponse.json({ error: 'Cannot upvote own wish' }, { status: 403 })
+    }
+    // Ersteller-Schutz!
+
     const existing = await prisma.wishUpvote.findFirst({
       where: { wishId: id, userId },
     })

--- a/src/app/event/[id]/page.tsx
+++ b/src/app/event/[id]/page.tsx
@@ -348,16 +348,21 @@ export default function EventDetailPage() {
           gap: 1,
         }}
       >
-        <Button
-          {...(joined ? { color: 'orange' } : {})}
-          onClick={joined ? deleteParticipation : createParticipation}
-        >
-          {joined ? 'Leave' : 'Participate'}
-        </Button>
-
-        {(joined || userId === event.trainerId) && (
-          <Button onClick={() => router.push(`/event/${id}/survey`)}>To Surveys</Button>
-        )}
+        <Box>
+          {userId !== event.trainerId && (
+            <Button
+              {...(joined ? { color: 'orange' } : {})}
+              onClick={joined ? deleteParticipation : createParticipation}
+            >
+              {joined ? 'Leave' : 'Participate'}
+            </Button>
+          )}
+        </Box>
+        <Box>
+          {(joined || userId === event.trainerId) && (
+            <Button onClick={() => router.push(`/event/${id}/survey`)}>To Surveys</Button>
+          )}
+        </Box>
       </Box>
 
       {deleteEvent && event?.eventId && (

--- a/src/app/event/[id]/survey/page.tsx
+++ b/src/app/event/[id]/survey/page.tsx
@@ -130,13 +130,15 @@ const Page = () => {
                   >
                     <Typography>{q.questionText}</Typography>
                     <Box sx={{ display: 'flex', alignItems: 'center', gap: 1 }}>
-                      <IconButton
-                        onClick={() =>
-                          setActiveAnswerId(activeAnswerId === q.questionId ? null : q.questionId)
-                        }
-                      >
-                        <QuestionAnswerIcon />
-                      </IconButton>
+                      {userId !== trainerId && (
+                        <IconButton
+                          onClick={() =>
+                            setActiveAnswerId(activeAnswerId === q.questionId ? null : q.questionId)
+                          }
+                        >
+                          <QuestionAnswerIcon />
+                        </IconButton>
+                      )}
                       {userId === trainerId && (
                         <>
                           <IconButton onClick={() => handleEditQuestion(q.questionId)}>

--- a/src/app/event/page.tsx
+++ b/src/app/event/page.tsx
@@ -113,6 +113,8 @@ export default function EventFeed() {
               createdAt={event.createdAt}
               initialJoined={event.joined}
               onParticipationChange={handleParticipationChange}
+              currentUserId={userId}
+              trainerId={event.users.userId}
             />
           ))}
         </Stack>

--- a/src/app/wish/[id]/page.tsx
+++ b/src/app/wish/[id]/page.tsx
@@ -5,7 +5,7 @@ import { useParams, useRouter } from 'next/navigation'
 import { api } from '@/lib/api'
 import { fetchUser } from '@/lib/user'
 import { Box, Typography, CircularProgress, Alert, Stack, IconButton } from '@mui/material'
-import { blue } from '@mui/material/colors'
+import { blue, grey } from '@mui/material/colors'
 import ThumbUpAltIcon from '@mui/icons-material/ThumbUpAlt'
 import ThumbUpAltOutlinedIcon from '@mui/icons-material/ThumbUpOutlined'
 import Button from '@/components/button'
@@ -144,24 +144,28 @@ export default function WishDetailPage() {
         </Box>
 
         {/* Buttons */}
-        <Stack direction='row' spacing={2} alignItems='center'>
+        <Stack direction='row' spacing={1} alignItems='center'>
           {/* Upvote */}
           <IconButton
             size='small'
             onClick={(e) => {
               e.stopPropagation()
-              handleUpvote()
+              if (!isCreator) {
+                handleUpvote()
+              }
             }}
             sx={{
               p: 0.5,
               transition: 'transform 150ms ease-in-out',
-              '&:hover': { transform: 'scale(1.1)' },
+              '&:hover': !isCreator ? { transform: 'scale(1.1)' } : undefined,
             }}
           >
             {isUpvoted ? (
               <ThumbUpAltIcon sx={{ color: blue[800], fontSize: 20 }} />
             ) : (
-              <ThumbUpAltOutlinedIcon sx={{ color: blue[500], fontSize: 20 }} />
+              <ThumbUpAltOutlinedIcon
+                sx={{ color: isCreator ? grey[500] : blue[500], fontSize: 20 }}
+              />
             )}
           </IconButton>
           <Typography variant='body2' color='text.secondary'>

--- a/src/app/wish/myWish/page.tsx
+++ b/src/app/wish/myWish/page.tsx
@@ -90,6 +90,7 @@ const Page = () => {
               createdAt={wish.createdAt}
               onClick={() => setSelectedMyWishes(wish)}
               deleteButton={true}
+              wishCreatorId={wish.users.userId}
             />
           ))}
         </Stack>

--- a/src/app/wish/page.tsx
+++ b/src/app/wish/page.tsx
@@ -115,6 +115,8 @@ export default function WishFeed() {
               onUpvote={() => handleUpvote(wish.wishId)}
               currentUpvotes={wish.currentUpvotes}
               onClick={() => router.push(`/wish/${wish.wishId}`)} //Nur noch routing zur [wishId] page
+              currentUserId={userId}
+              wishCreatorId={wish.users.userId}
             />
           ))}
         </Stack>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -15,6 +15,8 @@ interface EventCardProps {
   createdAt: string
   initialJoined: boolean
   onParticipationChange?: (eventId: string, joined: boolean) => void
+  currentUserId?: string | null
+  trainerId: string
 }
 
 export default function EventCard({
@@ -24,9 +26,12 @@ export default function EventCard({
   createdAt,
   initialJoined,
   onParticipationChange,
+  currentUserId,
+  trainerId,
 }: EventCardProps) {
   const [joined, setJoined] = useState(initialJoined)
   const router = useRouter()
+  const isOwnEvent = currentUserId === trainerId
 
   const createParticipation = async () => {
     try {
@@ -100,7 +105,12 @@ export default function EventCard({
             <Button
               onClick={(e) => {
                 e.stopPropagation()
-                createParticipation()
+                if (!isOwnEvent) createParticipation()
+              }}
+              sx={{
+                backgroundColor: isOwnEvent ? 'lightgrey' : 'primary.main',
+                color: isOwnEvent ? 'dimgray' : 'white',
+                cursor: 'pointer',
               }}
             >
               Participate

--- a/src/components/WishCard.tsx
+++ b/src/components/WishCard.tsx
@@ -17,6 +17,8 @@ interface WishCardProps {
   deleteButton?: boolean
   actionButton?: ReactNode
   onClick?: () => void
+  currentUserId?: string | null
+  wishCreatorId: string
 }
 
 export default function WishCard({
@@ -29,7 +31,11 @@ export default function WishCard({
   deleteButton = false,
   actionButton = null,
   onClick,
+  currentUserId,
+  wishCreatorId,
 }: WishCardProps) {
+  const isOwnWish = currentUserId === wishCreatorId
+
   return (
     <Card
       onClick={onClick}
@@ -65,14 +71,18 @@ export default function WishCard({
           size='small'
           onClick={(e) => {
             e.stopPropagation()
-            onUpvote?.()
+            if (!isOwnWish) {
+              onUpvote?.()
+            }
           }}
           sx={{ p: 0.5, mr: 0.5 }}
         >
           {isUpvoted ? (
             <ThumbUpAltIcon sx={{ color: blue[800], fontSize: 20 }} />
           ) : (
-            <ThumbUpAltOutlinedIcon sx={{ color: blue[500], fontSize: 20 }} />
+            <ThumbUpAltOutlinedIcon
+              sx={{ color: isOwnWish ? grey[500] : blue[500], fontSize: 20 }}
+            />
           )}
         </IconButton>
 


### PR DESCRIPTION
**Features & Logic:**

**1. Prevent Wish Creators from Liking Their Own Wishes**
- Frontend: Like button is shown but disabled for the wish creator.
- Backend: API checks userId === wish.wishCreator and returns a 403 Forbidden if the user tries to like their own wish.

**2. Prevent Event Organizers from Joining Their Own Events**
- Frontend: Participate button is visible but inactive for the organizer.
- Backend: eventParticipation API checks if the authenticated user is the organizer and blocks participation with a 403 Forbidden.

**3. Prevent Organizers from Answering Their Own Surveys**
- Frontend: Survey answer button is hidden for the event creator.
- Backend: surveyAnswer API blocks answer submissions from the event organizer.