### PR TITLE
SCRUM-134-Like-Funktion-Beim-Erstellen-automatisch-eigenen-Wunsch-liken

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14011,6 +14011,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/swr/-/swr-2.3.3.tgz",
       "integrity": "sha512-dshNvs3ExOqtZ6kJBaAsabhPdHyeY4P2cKwRCniDVifBMoG/SVI7tfLWqPXriVspf2Rg4tPzXJTnwaihIeFw2A==",
+      "license": "MIT",
       "dependencies": {
         "dequal": "^2.0.3",
         "use-sync-external-store": "^1.4.0"

--- a/src/app/api/wish/route.ts
+++ b/src/app/api/wish/route.ts
@@ -59,6 +59,13 @@ export async function POST(req: Request) {
       },
     })
 
+    await prisma.wishUpvote.create({
+      data: {
+        wishId: wish.wishId,
+        userId: user.id,
+      },
+    })
+
     return NextResponse.json({ message: 'created wish', wish }, { status: 200 })
   } catch (error) {
     return NextResponse.json({ error }, { status: 500 })

--- a/src/app/wish/[id]/page.tsx
+++ b/src/app/wish/[id]/page.tsx
@@ -161,7 +161,7 @@ export default function WishDetailPage() {
             }}
           >
             {isUpvoted ? (
-              <ThumbUpAltIcon sx={{ color: blue[800], fontSize: 20 }} />
+              <ThumbUpAltIcon sx={{ color: isCreator ? grey[500] : blue[800], fontSize: 20 }} />
             ) : (
               <ThumbUpAltOutlinedIcon
                 sx={{ color: isCreator ? grey[500] : blue[500], fontSize: 20 }}

--- a/src/components/WishCard.tsx
+++ b/src/components/WishCard.tsx
@@ -78,7 +78,7 @@ export default function WishCard({
           sx={{ p: 0.5, mr: 0.5 }}
         >
           {isUpvoted ? (
-            <ThumbUpAltIcon sx={{ color: blue[800], fontSize: 20 }} />
+            <ThumbUpAltIcon sx={{ color: isOwnWish ? grey[500] : blue[800], fontSize: 20 }} />
           ) : (
             <ThumbUpAltOutlinedIcon
               sx={{ color: isOwnWish ? grey[500] : blue[500], fontSize: 20 }}


### PR DESCRIPTION
- PR adds a feature that automatically creates a like from the creator when a new wish is submitted.
- New wishes now always start with 1 like from the wishcreator.
- Prevents the creator from liking their own wish manually (as intended).
