### PR TITLE
Scrum 128 participate button fuer ersteller komplett entfernen nicht ausgegraut

### DIFF
--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -91,31 +91,27 @@ export default function EventCard({
         </Typography>
 
         <Box display='flex' justifyContent='space-between' mt={2}>
-          {joined ? (
-            <Button
-              color='orange'
-              onClick={(e) => {
-                e.stopPropagation()
-                deleteParticipation()
-              }}
-            >
-              Leave
-            </Button>
-          ) : (
-            <Button
-              onClick={(e) => {
-                e.stopPropagation()
-                if (!isOwnEvent) createParticipation()
-              }}
-              sx={{
-                backgroundColor: isOwnEvent ? 'lightgrey' : 'primary.main',
-                color: isOwnEvent ? 'dimgray' : 'white',
-                cursor: 'pointer',
-              }}
-            >
-              Participate
-            </Button>
-          )}
+          {!isOwnEvent &&
+            (joined ? (
+              <Button
+                color='orange'
+                onClick={(e) => {
+                  e.stopPropagation()
+                  deleteParticipation()
+                }}
+              >
+                Leave
+              </Button>
+            ) : (
+              <Button
+                onClick={(e) => {
+                  e.stopPropagation()
+                  createParticipation()
+                }}
+              >
+                Participate
+              </Button>
+            ))}
         </Box>
       </Card>
     </Box>


### PR DESCRIPTION
PR updates the EventCard component to fully hide the "Participate"/"Leave" button for users who created the event themselves.

Previously, the button was disabled or inactive, but still rendered. Now:
- Event creators no longer see any participation button on their own events.
- This improves clarity and avoids offering irrelevant actions to the event organizer.

=> No changes were made to participation logic for other users.