### PR TITLE
SCRUM-140-Scrollbar-darf-nicht-in-Header-schneiden-nur-im-Content-Bereich-sichtbar

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -26,9 +26,9 @@ export default async function RootLayout({
 
   return (
     <html lang='en'>
-      <body>
+      <body style={{ margin: 0, overflow: 'hidden' }}>
         {showNavigation && <Header />}
-        <div style={{ display: 'flex', width: '100%' }}>
+        <div style={{ display: 'flex', width: '100%', height: '100vh' }}>
           {showNavigation && <Sidebar />}
           <ContentWrapper showNavigation={showNavigation}>
             <ErrorBoundaryWrapper>

--- a/src/components/layoutContentWrapper.tsx
+++ b/src/components/layoutContentWrapper.tsx
@@ -17,11 +17,14 @@ const ContentWrapper = ({
     <Box
       sx={{
         marginLeft: showNavigation && !IsMobile() ? `${drawerWidth}px` : 0,
-        marginTop: showNavigation ? `${headerHeight}px` : 0,
+        height: showNavigation ? `calc(100vh - ${headerHeight}px)` : '100vh',
+        overflowY: 'auto',
         px: IsMobile() ? 2 : 4,
+        scrollbarGutter: 'stable',
         py: 2,
         flexGrow: 1,
-        overflowX: 'hidden',
+        paddingTop: 2,
+        mt: `${headerHeight}px`,
       }}
     >
       {children}


### PR DESCRIPTION
PR fixes the layout behavior where the vertical scrollbar overlapped the fixed header and caused content shifts when navigating between pages.

Changes include:
- Scrollbar is now only applied to the content area, not the whole page.
- `scrollbar-gutter: stable` ensures no layout "jumps" when scrollbar appears or disappears.

Result:
- The header stays fixed and clean.
- The scrollbar appears only within the scrollable content.
- No flickering or content shift when switching pages.
