### PR TITLE
SCRUM-154-Ich-kann-nicht-sofort-ein-event-erstellen-von-einem-wish

### DIFF
--- a/src/app/api/event/route.ts
+++ b/src/app/api/event/route.ts
@@ -62,7 +62,7 @@ export async function POST(req: Request) {
         where: { wishId },
         data: { isConvertedToEvent: true },
       })
-      await addWishUpvotersAsParticipants(wishId, createdEvent.eventId)
+      await addWishUpvotersAsParticipants(wishId, createdEvent.eventId, user.id)
     }
 
     /*

--- a/src/app/event/create/page.tsx
+++ b/src/app/event/create/page.tsx
@@ -31,6 +31,7 @@ const Page = () => {
 
   const [error, setError] = useState(false)
   const [disabled, setDisabled] = useState(true)
+  const [titleTouched, setTitleTouched] = useState(false)
 
   useLayoutEffect(() => {
     setIsClient(true)
@@ -43,8 +44,11 @@ const Page = () => {
         try {
           const res = await api.get(`/wish/${wishId}`)
           const wish = res.data
-          setPrefilledTitle(wish.title || '')
-          setPrefilledDescription(wish.description || '')
+          const title = wish.title || ''
+          const description = wish.description || ''
+
+          setPrefilledTitle(title)
+          setPrefilledDescription(description)
         } catch (error) {
           console.error('Fehler beim Laden des Wishes:', error)
         }
@@ -52,6 +56,16 @@ const Page = () => {
       fetchWish()
     }
   }, [searchParams])
+
+  useEffect(() => {
+    if (prefilledTitle.trim() === '') {
+      setError(true)
+      setDisabled(true)
+    } else {
+      setError(false)
+      setDisabled(false)
+    }
+  }, [prefilledTitle])
 
   if (!isClient) return <Box>Loading...</Box>
 
@@ -105,16 +119,6 @@ const Page = () => {
         </Box>
       </Box>
     )
-  }
-
-  const checkInput = (event: string) => {
-    if (event.trim() === '') {
-      setError(true)
-      setDisabled(true)
-    } else {
-      setError(false)
-      setDisabled(false)
-    }
   }
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
@@ -190,13 +194,14 @@ const Page = () => {
               margin='normal'
               name='title'
               required
-              error={error}
+              error={titleTouched && error}
               value={prefilledTitle}
               onChange={(e) => {
                 setPrefilledTitle(e.target.value)
-                checkInput(e.target.value)
+                setTitleTouched(true)
               }}
             />
+
             <TextField
               label='Description'
               variant='outlined'

--- a/src/lib/eventParticipationService.ts
+++ b/src/lib/eventParticipationService.ts
@@ -1,18 +1,24 @@
 import { prisma } from '@/lib/client'
 
-export async function addWishUpvotersAsParticipants(wishId: string, eventId: string) {
+export async function addWishUpvotersAsParticipants(
+  wishId: string,
+  eventId: string,
+  organizerId: string
+) {
   const upvotes = await prisma.wishUpvote.findMany({
     where: { wishId },
     select: { userId: true },
   })
 
   for (const upvote of upvotes) {
-    await prisma.eventParticipation.create({
-      data: {
-        eventId,
-        participantId: upvote.userId,
-      },
-    })
+    if (upvote.userId !== organizerId) {
+      await prisma.eventParticipation.create({
+        data: {
+          eventId,
+          participantId: upvote.userId,
+        },
+      })
+    }
   }
 }
 

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -2,12 +2,17 @@ import { createTheme } from '@mui/material/styles'
 
 const theme = createTheme({
   typography: {
-    fontFamily: 'Arial, Helvetica, sans-serif',
+    fontFamily: 'Arial, "Liberation Sans", sans-serif',
+  },
+  components: {
+    MuiCssBaseline: {
+      styleOverrides: {
+        body: {
+          fontFamily: 'Arial, "Liberation Sans", sans-serif',
+        },
+      },
+    },
   },
 })
 
 export default theme
-
-// Arial: gewünschte Hauptschrift
-// Fallback Helvecita: zweite Wahl (auf macOS und vielen Linux-Systemen)
-// Fallback sans-serif: dritte Wahl (generische System-Schrift, falls Arial und Helvecita fehlen)

--- a/src/providers/theme-provider.tsx
+++ b/src/providers/theme-provider.tsx
@@ -1,9 +1,15 @@
 'use client'
 
 import { ThemeProvider } from '@mui/material/styles'
+import { CssBaseline } from '@mui/material'
 import theme from '@/lib/theme'
 import { ReactNode } from 'react'
 
 export default function MuiThemeProvider({ children }: { children: ReactNode }) {
-  return <ThemeProvider theme={theme}>{children}</ThemeProvider>
+  return (
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      {children}
+    </ThemeProvider>
+  )
 }


### PR DESCRIPTION
- Fixed: Events can now be created from wishes again
- Fixed: Organizer is no longer added as participant during wish-based event creation
- Fixed: "Show participating events only" no longer includes events organized by the user
- Updated: Global font family — replaced commercial fallback with free alternatives (Liberation Sans)
- Minor UI adjustments (ThemeProvider, layout cleanup, font fallback chain)