### PR TITLE
SCRUM-163-Text-Input-beim-Survey-beantworten-muss-weissen-hintergrund-bekommen

### DIFF
--- a/src/components/surveyAnswerCard.tsx
+++ b/src/components/surveyAnswerCard.tsx
@@ -110,7 +110,6 @@ const SurveyAnswerCard = ({
             ))}
           </RadioGroup>
         )}
-
         {question.type === 'text' && (
           <TextField
             fullWidth
@@ -119,6 +118,14 @@ const SurveyAnswerCard = ({
             onChange={(e) => {
               setLocalAnswer(e.target.value)
               enableSaveSurveyQuestionButton()
+            }}
+            variant='outlined'
+            slotProps={{
+              input: {
+                sx: {
+                  backgroundColor: 'white',
+                },
+              },
             }}
           />
         )}


### PR DESCRIPTION
white background for question option "text field" in page /survey